### PR TITLE
feat(make): asdf-doctor を Makefile / docs から公開 (#44)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 # Claude Voice Integration - Development Makefile
 # ローカル開発用の品質チェックツール
 
-.PHONY: all check lint format test security clean install-tools help
+.PHONY: all check lint format test security clean install-tools help \
+	asdf-doctor asdf-clean-dry asdf-sync
 .DEFAULT_GOAL := help
 
 # 変数定義
@@ -338,6 +339,38 @@ stats:
 	echo "  総行数: $$total_lines"
 	@total_functions=$$(find $(CLAUDE_DIR) -name "*.sh" -exec grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() *{" {} + 2>/dev/null | awk -F: '{sum+=$$2} END {print sum}'); \
 	echo "  総関数数: $$total_functions"
+
+# ============================================================================
+# asdf 棚卸し（運用ツール）
+# ============================================================================
+
+ASDF_DOCTOR_SCRIPT := scripts/asdf-doctor.sh
+
+## 🩺 asdf 診断: .tool-versions ⇄ installed の整合性チェック
+asdf-doctor:
+	@test -x $(ASDF_DOCTOR_SCRIPT) || { \
+		echo "$(RED)❌ $(ASDF_DOCTOR_SCRIPT) not found or not executable$(NC)" >&2; \
+		exit 1; \
+	}
+	@./$(ASDF_DOCTOR_SCRIPT)
+
+## 🧹 asdf 削除候補表示（dry-run、実行はしない）
+asdf-clean-dry:
+	@test -x $(ASDF_DOCTOR_SCRIPT) || { \
+		echo "$(RED)❌ $(ASDF_DOCTOR_SCRIPT) not found or not executable$(NC)" >&2; \
+		exit 1; \
+	}
+	@./$(ASDF_DOCTOR_SCRIPT) --clean-suggestions
+
+## 🔄 asdf プラグインインデックス・全プラグインを最新化
+asdf-sync:
+	@command -v asdf >/dev/null 2>&1 || { \
+		echo "$(YELLOW)⚠️  asdf not found, skip$(NC)" >&2; \
+		exit 0; \
+	}
+	@echo "$(CYAN)🔄 asdf プラグインを更新中...$(NC)"
+	@asdf plugin update --all
+	@echo "$(GREEN)✅ 完了。各プロジェクトで 'asdf install' を実行してください。$(NC)"
 
 # ============================================================================
 # ヘルプ

--- a/docs/managed-tools.md
+++ b/docs/managed-tools.md
@@ -39,6 +39,8 @@
 
 > Homebrew (`Brewfile`) およびマシン構築の運用ナレッジは外部リポ [ysano/machine-management](https://github.com/ysano/machine-management) で管理。
 
+> **asdf 棚卸し**: `make asdf-doctor` で `.tool-versions` と installed の整合性チェック（読み取り専用）。削除候補は `make asdf-clean-dry` で確認後、手動 `asdf uninstall <plugin> <version>` を推奨。プラグインインデックス更新は `make asdf-sync`。
+
 ### プラットフォーム固有
 
 | ツール | Config ファイル | デプロイ方法 | 対応OS |


### PR DESCRIPTION
## Summary

Story 1 (#43) の `scripts/asdf-doctor.sh` を `make asdf-doctor` 等の統一インタフェース経由で呼び出せるようにし、`docs/managed-tools.md` に運用フローを追記。

## Spec Reference

`docs/ai-dlc/spec-asdf-cleanup.md` — Story 2 / Issue #44

## AI-DLC Metrics

- **Intent**: chore
- **Size**: S (1 Concern: 公開窓口、2 ファイル)
- **AI-Confidence**: High（spec 5/5、auto-drive 適格）
- **Churn**: 0 回

## Verification

| Step | Command | Result |
|---|---|---|
| 1 | `make -n asdf-doctor` (syntax) | parse OK |
| 2 | `make asdf-doctor` | 5 セクション report 出力（unused / missing / healthy / unused_plugins / index freshness） |
| 3 | `make asdf-clean-dry` | uninstall コマンド形式出力 |
| 4 | script rename → `make asdf-doctor` | 赤字エラー + exit 2 で fail |
| 5 | `make help` | 3 つの asdf-* target が auto-detect で掲載 |
| 6 | 既存 target | 影響なし |

## 副次的に判明した状態

実機検証で asdf-doctor が `tflint/terragrunt/tfsec` を "missing" 報告 — 実際 `~/.asdf/installs/` に該当ディレクトリが存在しなかった。これは Story 1 の機能が正常に動作している証で、Phase A の進行中に該当 plugin が uninstall された可能性を示唆。本 PR の成果物には影響なし。

なお `vendor/bundle/` 配下の 3rd-party gem の `.tool-versions` も検出されている（asdf-doctor の find は vendor/ を除外していないため）。これは Story 1 改善候補として別 Issue 化検討可能だが、本 Story スコープ外。

## Test plan

- [x] Makefile 構文チェック (`make -n asdf-doctor`)
- [x] 全 3 target 動作確認
- [x] 前提チェック動作確認（script rename）
- [x] `make help` に自動掲載確認
- [x] 既存 target 影響なし
- [x] `docs/managed-tools.md` Markdown 整合性確認

## Files Changed

- 修正: `Makefile` (+35 行) — `.PHONY` 拡張、asdf 棚卸しセクション + 3 target
- 修正: `docs/managed-tools.md` (+1 行) — パッケージ管理直下に運用 note

Closes #44