### PR TITLE
refactor(zsh): OMZ asdf plugin を除去し補完を直接生成方式に置換 (#46)

### DIFF
--- a/.zsh/zinit_setup.zsh
+++ b/.zsh/zinit_setup.zsh
@@ -119,8 +119,13 @@ setup_dev_tools() {
         _asdf_comp_file="$_asdf_comp_dir/_asdf"
         if [[ -n "$_asdf_bin" ]] && \
            { [[ ! -f "$_asdf_comp_file" ]] || [[ "$_asdf_bin" -nt "$_asdf_comp_file" ]]; }; then
+            # 失敗時に空 / 部分ファイルを残さないよう一時ファイル経由で atomic に置換。
             mkdir -p "$_asdf_comp_dir"
-            "$_asdf_bin" completion zsh > "$_asdf_comp_file" 2>/dev/null
+            if "$_asdf_bin" completion zsh > "$_asdf_comp_file.tmp" 2>/dev/null; then
+                mv "$_asdf_comp_file.tmp" "$_asdf_comp_file"
+            else
+                rm -f "$_asdf_comp_file.tmp"
+            fi
         fi
 
         # plugin-index の週次自動更新（バックグラウンド・非同期）

--- a/.zsh/zinit_setup.zsh
+++ b/.zsh/zinit_setup.zsh
@@ -105,8 +105,23 @@ setup_dev_tools() {
     
     # ASDF version manager
     if [[ -d "${ASDF_DATA_DIR:-$HOME/.asdf}" ]]; then
-        zinit ice wait lucid
-        zinit snippet OMZP::asdf/asdf.plugin.zsh
+        # 補完ファイル ~/.asdf/completions/_asdf を遅延生成。
+        # asdf 0.16+ では asdf binary が `asdf completion zsh` を提供するが、
+        # 自動配置はされないため zsh 起動時に必要なら生成する。
+        # asdf binary が補完ファイルより新しい場合のみ再生成（アップグレード追従）。
+        # fpath への登録は .zsh/functions.zsh が担当。
+        # 旧来の OMZP::asdf/asdf.plugin.zsh は asdf 0.x の asdf.sh を source する
+        # 前提で、asdf 0.16+ では asdf.sh 自体が存在せず実質 no-op だったため除去。
+        # shim PATH は .zprofile の setup_asdf() に集約済み（commit 7c7a033）。
+        local _asdf_bin _asdf_comp_dir _asdf_comp_file
+        _asdf_bin=$(command -v asdf 2>/dev/null)
+        _asdf_comp_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/completions"
+        _asdf_comp_file="$_asdf_comp_dir/_asdf"
+        if [[ -n "$_asdf_bin" ]] && \
+           { [[ ! -f "$_asdf_comp_file" ]] || [[ "$_asdf_bin" -nt "$_asdf_comp_file" ]]; }; then
+            mkdir -p "$_asdf_comp_dir"
+            "$_asdf_bin" completion zsh > "$_asdf_comp_file" 2>/dev/null
+        fi
 
         # plugin-index の週次自動更新（バックグラウンド・非同期）
         # sentinel mtime が 7 日以上前なら 'asdf plugin update --all' を disown 起動。


### PR DESCRIPTION
## Summary

`zinit_setup.zsh:setup_dev_tools()` から `OMZP::asdf/asdf.plugin.zsh` を除去し、補完を `asdf completion zsh` 出力ファイル経由で提供する方式に置換。

## Spec Reference

`docs/ai-dlc/spec-asdf-cleanup.md` — Story 4 / Issue #46

## AI-DLC Metrics

- **Intent**: chore (refactor)
- **Size**: S (1 Concern: 形骸化設定の整理 + 補完代替実装、1 ファイル、+17 -2 行)
- **AI-Confidence**: High（spec 5/5、検証段階で代替実装の必要性を認識）
- **Churn**: 0 回（spec の Constraints 通り「検証 NG → 代替実装」を実施）

## 背景

`OMZP::asdf/asdf.plugin.zsh` は asdf 0.x の `$ASDF_DIR/asdf.sh` を `source` する設計。asdf 0.16+ で Go バイナリ化され `asdf.sh` 自体が存在せず実質 no-op になっていた。shim PATH 設定は既に `.zprofile` の `setup_asdf()` に集約済み（commit 7c7a033）。

## 検証フロー

spec の検証手順に従い、まずコメントアウトして問題を発見 → 代替実装。

| Step | 結果 |
|---|---|
| 1. snippet コメントアウト → zsh 再起動 | asdf, which node 等は OK |
| 2. `_comps[asdf]` 確認 | **NOT REGISTERED**（補完欠落を発見） |
| 3. spec Constraints「削除ではなく代替実装」発動 | 補完直接生成方式を実装 |

## 代替実装

```zsh
local _asdf_bin _asdf_comp_dir _asdf_comp_file
_asdf_bin=$(command -v asdf 2>/dev/null)
_asdf_comp_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/completions"
_asdf_comp_file="$_asdf_comp_dir/_asdf"
if [[ -n "$_asdf_bin" ]] && \
   { [[ ! -f "$_asdf_comp_file" ]] || [[ "$_asdf_bin" -nt "$_asdf_comp_file" ]]; }; then
    mkdir -p "$_asdf_comp_dir"
    "$_asdf_bin" completion zsh > "$_asdf_comp_file" 2>/dev/null
fi
```

設計ポイント:
- **upgrade 追従**: `asdf binary -nt completion file` で asdf upgrade 時に自動再生成
- **コスト最小**: 通常起動時は `[[ -f ... ]] && [[ ... -nt ... ]]` の 2 stat のみ
- **fpath 登録**: 既存の `.zsh/functions.zsh:22` (`fpath=(${ASDF_DATA_DIR:-$HOME/.asdf}/completions $fpath)`) が継続担当

## Verification

| Step | Method | Result |
|---|---|---|
| 1 | `zsh -n .zsh/zinit_setup.zsh` | OK |
| 2 | OMZ 有/無 で `asdf --version` 出力比較 | 一致 |
| 3 | OMZ 有/無 で `asdf current` 出力比較 | 一致 |
| 4 | OMZ 有/無 で `which node/python/ruby` 比較 | 一致 |
| 5 | 削除後 `compinit` → `_comps[asdf]` | REGISTERED |
| 6 | 起動時間 5 回平均 | 0.408s（Story 3 後 0.460s → 0.05s 短縮、baseline 0.630s から計 0.22s 短縮） |
| 7 | 既存 `test_git_worktree.zsh` / `test_resurrect.sh` syntax | OK |

## Test plan

- [x] zsh 構文チェック
- [x] asdf binary / shim 動作不変
- [x] 補完登録（compinit 後 `_comps[asdf]` 確認）
- [x] 起動時間 ±50ms 以内（実測 −0.05s 改善）
- [x] 補完ファイル自動生成（初回起動 / asdf upgrade 時）
- [x] 既存テスト保護

## Files Changed

- 修正: `.zsh/zinit_setup.zsh` (+17 -2 行) — OMZ snippet 除去、補完直接生成ロジック追加

Closes #46